### PR TITLE
Fix ReferenceError: "TouchEvent is not defined" in Firefox

### DIFF
--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -203,7 +203,7 @@ export const Draggable: DirectiveOptions = {
 					top: event.clientY
 				}
 			}
-			if (event instanceof TouchEvent) {
+			if (window.TouchEvent && event instanceof TouchEvent) {
 				const touch = event.changedTouches[event.changedTouches.length - 1];
 				return {
 					left: touch.clientX,


### PR DESCRIPTION
In Firefox a ReferenceError: "TouchEvent is not defined" is thrown. This commit fixes it by simply inserting "window.TouchEvent && " into the if-check in line 206